### PR TITLE
feat(loa): configurable BEAUVOIR.md path via LOA_SOUL_SOURCE

### DIFF
--- a/deploy/start-loa-dev.sh
+++ b/deploy/start-loa-dev.sh
@@ -21,6 +21,7 @@ echo "[loa-dev] Loa Development Mode"
 echo "[loa-dev] =============================================="
 echo "[loa-dev] BEAUVOIR_DEV_MODE=${BEAUVOIR_DEV_MODE:-not set}"
 echo "[loa-dev] CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR:-not set}"
+echo "[loa-dev] LOA_SOUL_SOURCE=${LOA_SOUL_SOURCE:-/workspace/grimoires/loa/BEAUVOIR.md}"
 if [ -n "${CLAWDBOT_GATEWAY_TOKEN:-}" ]; then
     echo "[loa-dev] CLAWDBOT_GATEWAY_TOKEN=<set>"
 else

--- a/deploy/start-loa.sh
+++ b/deploy/start-loa.sh
@@ -25,10 +25,15 @@ WORKSPACE="/root/clawd"
 LOA_WORKSPACE="/workspace"
 GRIMOIRE_DIR="$LOA_WORKSPACE/grimoires/loa"
 
+# LOA Soul Source - configurable BEAUVOIR.md path (Loa v1.27.0 pattern)
+# Export for loa-soul-generator.ts to read via process.env
+export LOA_SOUL_SOURCE="${LOA_SOUL_SOURCE:-$GRIMOIRE_DIR/BEAUVOIR.md}"
+
 echo "[loa] Starting Loa Cloud Stack"
 echo "[loa] Config directory: $CONFIG_DIR"
 echo "[loa] Workspace: $WORKSPACE"
 echo "[loa] Loa workspace: $LOA_WORKSPACE"
+echo "[loa] LOA_SOUL_SOURCE=$LOA_SOUL_SOURCE"
 echo "[loa] BEAUVOIR_DEV_MODE=${BEAUVOIR_DEV_MODE:-0}"
 
 # Create directories

--- a/grimoires/loa/soul-init-prd.md
+++ b/grimoires/loa/soul-init-prd.md
@@ -1,0 +1,201 @@
+# PRD: LOA-OpenClaw Path Integration Refactor
+
+> **Version**: 1.0.0
+> **Status**: Draft
+> **Created**: 2026-02-04
+> **Branch**: feature/soul-init
+
+---
+
+## Executive Summary
+
+Refactor the LOA-OpenClaw integration to use configurable paths instead of hardcoded values, aligning with Loa framework v1.27.0's configurable paths feature. This enables zero-code changes when deploying to different environments while maintaining persistence guarantees.
+
+---
+
+## Problem Statement
+
+### Current State
+
+The `loa-soul-generator.ts` file hardcodes the BEAUVOIR.md path:
+
+```typescript
+const beauvoirPath = path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+```
+
+This creates coupling between:
+
+1. LOA identity source location
+2. OpenClaw workspace structure
+3. Deployment environment assumptions
+
+### Impact
+
+- **Inflexibility**: Cannot relocate BEAUVOIR.md without code changes
+- **Environment mismatch**: Dev/prod may have different directory structures
+- **Integration friction**: Grafting LOA into OpenClaw requires understanding internal paths
+
+### Root Cause
+
+The original implementation prioritized quick integration over configurability. With Loa v1.27.0's `path-lib.sh` providing a pattern for configurable paths, we can now align with framework conventions.
+
+---
+
+## Goals
+
+### Primary Goals
+
+| Goal                    | Metric                         | Priority |
+| ----------------------- | ------------------------------ | -------- |
+| **Zero data loss**      | No persistence regressions     | P0       |
+| **Configurable paths**  | BEAUVOIR.md path via env var   | P0       |
+| **Backward compatible** | Existing deployments unchanged | P0       |
+
+### Non-Goals
+
+- Changing OpenClaw's workspace structure
+- Modifying the persistence/R2 backup system
+- Adding new configuration file formats
+
+---
+
+## Proposed Solution
+
+### Overview
+
+Add environment variable support to `loa-soul-generator.ts` following Loa's `path-lib.sh` pattern:
+
+```typescript
+// Before: Hardcoded
+const beauvoirPath = path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+
+// After: Configurable with default
+const beauvoirPath =
+  process.env.LOA_SOUL_SOURCE ?? path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+```
+
+### Environment Variables
+
+| Variable          | Description                  | Default                                 |
+| ----------------- | ---------------------------- | --------------------------------------- |
+| `LOA_SOUL_SOURCE` | Absolute path to BEAUVOIR.md | `{workspace}/grimoires/loa/BEAUVOIR.md` |
+
+### Behavior
+
+1. **If `LOA_SOUL_SOURCE` is set**: Use the specified absolute path
+2. **If not set**: Use the default path (current behavior)
+3. **If file not found**: Return null, fallback to default SOUL.md template
+
+---
+
+## Technical Design
+
+### Changes Required
+
+| File                               | Change                   | LOC |
+| ---------------------------------- | ------------------------ | --- |
+| `src/agents/loa-soul-generator.ts` | Add env var check        | ~5  |
+| `deploy/start-loa.sh`              | Export `LOA_SOUL_SOURCE` | ~2  |
+| `deploy/start-loa-dev.sh`          | Export `LOA_SOUL_SOURCE` | ~2  |
+
+**Total**: ~9 lines changed
+
+### Path Resolution Logic
+
+```typescript
+function resolveSoulSourcePath(workspaceDir: string): string {
+  // 1. Check environment variable (absolute path)
+  if (process.env.LOA_SOUL_SOURCE) {
+    return process.env.LOA_SOUL_SOURCE;
+  }
+
+  // 2. Default: relative to workspace
+  return path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+}
+```
+
+### Persistence Guarantee
+
+The existing persistence model is **unchanged**:
+
+| Environment | Persistence Mechanism  | BEAUVOIR.md Location                   |
+| ----------- | ---------------------- | -------------------------------------- |
+| Dev         | Volume mount from host | `/workspace/grimoires/loa/BEAUVOIR.md` |
+| Prod        | R2 backup/restore      | `/workspace/grimoires/loa/BEAUVOIR.md` |
+
+The symlink at `/root/.openclaw/workspace/grimoires/loa` → `/workspace/grimoires/loa` ensures the path works from the workspace context.
+
+---
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] `LOA_SOUL_SOURCE` env var overrides default BEAUVOIR.md path
+- [ ] Unset env var uses default path (backward compatible)
+- [ ] Invalid path returns null (graceful degradation)
+- [ ] SOUL.md generated correctly from custom path
+
+### Non-Functional
+
+- [ ] No changes to persistence behavior
+- [ ] No changes to R2 backup/restore
+- [ ] Existing deployments work without modification
+
+### Testing
+
+- [ ] Unit test: env var override
+- [ ] Unit test: default path fallback
+- [ ] E2E test: container startup with custom path
+- [ ] E2E test: container startup without env var (regression)
+
+---
+
+## Rollout Plan
+
+### Phase 1: Implementation
+
+- Modify `loa-soul-generator.ts`
+- Update startup scripts
+
+### Phase 2: Testing
+
+- Run existing E2E tests
+- Verify dev container works
+- Verify prod deployment unchanged
+
+### Phase 3: Documentation
+
+- Update BEAUVOIR.md comment header
+- Update grimoires README if present
+
+---
+
+## Risks & Mitigations
+
+| Risk                          | Likelihood | Impact | Mitigation                           |
+| ----------------------------- | ---------- | ------ | ------------------------------------ |
+| Path resolution edge cases    | Low        | Medium | Validate absolute vs relative paths  |
+| Env var not propagated        | Low        | High   | Test in both dev and prod containers |
+| Breaking existing deployments | Very Low   | High   | Default maintains current behavior   |
+
+---
+
+## Dependencies
+
+- Loa v1.27.0 (already merged) - provides pattern reference
+- No external dependencies required
+
+---
+
+## Success Metrics
+
+| Metric              | Target  | Measurement              |
+| ------------------- | ------- | ------------------------ |
+| Code change size    | <15 LOC | Git diff                 |
+| Regression rate     | 0%      | E2E test pass rate       |
+| Deployment friction | None    | No config changes needed |
+
+---
+
+_Generated by Loa Simstim Workflow_

--- a/grimoires/loa/soul-init-sdd.md
+++ b/grimoires/loa/soul-init-sdd.md
@@ -1,0 +1,233 @@
+# SDD: LOA-OpenClaw Path Integration Refactor
+
+> **Version**: 1.0.0
+> **PRD Reference**: `grimoires/loa/soul-init-prd.md`
+> **Created**: 2026-02-04
+
+---
+
+## Architecture Overview
+
+This is a **surgical refactor** - minimal code changes to add environment variable support for the BEAUVOIR.md path. No architectural changes to OpenClaw or the persistence system.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OpenClaw Workspace                        │
+│                  (~/.openclaw/workspace/)                    │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────┐    ┌──────────────────┐    ┌─────────────┐    │
+│  │ SOUL.md │◄───│ loa-soul-gen.ts  │◄───│ BEAUVOIR.md │    │
+│  │ (root)  │    │                  │    │ (configurable)   │
+│  └─────────┘    └────────┬─────────┘    └─────────────┘    │
+│                          │                     ▲            │
+│                          │                     │            │
+│                   ┌──────▼──────┐              │            │
+│                   │ ENV CHECK   │──────────────┘            │
+│                   │LOA_SOUL_SRC │                           │
+│                   └─────────────┘                           │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Detailed Design
+
+### 1. Modified Function: `tryGenerateSoulFromBeauvoir`
+
+**File**: `src/agents/loa-soul-generator.ts`
+
+**Before**:
+
+```typescript
+export async function tryGenerateSoulFromBeauvoir(workspaceDir: string): Promise<string | null> {
+  const beauvoirPath = path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+
+  try {
+    const content = await fs.readFile(beauvoirPath, "utf-8");
+    return transformBeauvoirToSoul(content);
+  } catch {
+    return null;
+  }
+}
+```
+
+**After**:
+
+```typescript
+export async function tryGenerateSoulFromBeauvoir(workspaceDir: string): Promise<string | null> {
+  // Support configurable path via environment variable (Loa v1.27.0 pattern)
+  const beauvoirPath =
+    process.env.LOA_SOUL_SOURCE ?? path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+
+  try {
+    const content = await fs.readFile(beauvoirPath, "utf-8");
+    return transformBeauvoirToSoul(content);
+  } catch {
+    // BEAUVOIR.md not found or unreadable - caller will use fallback
+    return null;
+  }
+}
+```
+
+**Change**: +2 lines, 0 lines removed
+
+### 2. Startup Script Updates
+
+#### `deploy/start-loa.sh`
+
+Add after the `GRIMOIRE_DIR` definition (~line 26):
+
+```bash
+# LOA Soul Source - configurable BEAUVOIR.md path
+# Follows Loa v1.27.0 path-lib.sh pattern
+export LOA_SOUL_SOURCE="${LOA_SOUL_SOURCE:-$GRIMOIRE_DIR/BEAUVOIR.md}"
+```
+
+#### `deploy/start-loa-dev.sh`
+
+Add in the environment logging section (~line 22):
+
+```bash
+echo "[loa-dev] LOA_SOUL_SOURCE=${LOA_SOUL_SOURCE:-$GRIMOIRE_DIR/BEAUVOIR.md}"
+```
+
+### 3. Path Resolution Flow
+
+```
+tryGenerateSoulFromBeauvoir(workspaceDir)
+    │
+    ▼
+┌───────────────────────────────────────┐
+│ process.env.LOA_SOUL_SOURCE set?      │
+└───────────────────────────────────────┘
+    │                    │
+    │ Yes                │ No
+    ▼                    ▼
+┌─────────────┐    ┌─────────────────────────────────┐
+│ Use env var │    │ Use default:                    │
+│ (absolute)  │    │ {workspaceDir}/grimoires/loa/   │
+└─────────────┘    │ BEAUVOIR.md                     │
+    │              └─────────────────────────────────┘
+    │                    │
+    └────────┬───────────┘
+             ▼
+┌───────────────────────────────────────┐
+│ fs.readFile(beauvoirPath)             │
+└───────────────────────────────────────┘
+    │                    │
+    │ Success            │ Error
+    ▼                    ▼
+┌─────────────┐    ┌─────────────────────┐
+│ Transform   │    │ Return null         │
+│ to SOUL.md  │    │ (use default tmpl)  │
+└─────────────┘    └─────────────────────┘
+```
+
+---
+
+## Data Model
+
+No data model changes. The transformation logic remains identical.
+
+---
+
+## API Changes
+
+No API changes. The function signature remains:
+
+```typescript
+tryGenerateSoulFromBeauvoir(workspaceDir: string): Promise<string | null>
+```
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable          | Type          | Default                                 | Description                  |
+| ----------------- | ------------- | --------------------------------------- | ---------------------------- |
+| `LOA_SOUL_SOURCE` | string (path) | `{workspace}/grimoires/loa/BEAUVOIR.md` | Absolute path to BEAUVOIR.md |
+
+### Usage Examples
+
+```bash
+# Default (no change needed)
+# Uses: /root/.openclaw/workspace/grimoires/loa/BEAUVOIR.md
+
+# Custom location
+export LOA_SOUL_SOURCE="/custom/path/to/BEAUVOIR.md"
+
+# Via docker-compose
+environment:
+  LOA_SOUL_SOURCE: /data/identity/BEAUVOIR.md
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+**File**: `src/agents/__tests__/loa-soul-generator.test.ts` (new or extend existing)
+
+```typescript
+describe("tryGenerateSoulFromBeauvoir", () => {
+  it("uses LOA_SOUL_SOURCE env var when set", async () => {
+    process.env.LOA_SOUL_SOURCE = "/custom/BEAUVOIR.md";
+    // Mock fs.readFile to track called path
+    // Assert custom path was used
+  });
+
+  it("falls back to default path when env var not set", async () => {
+    delete process.env.LOA_SOUL_SOURCE;
+    // Assert default path constructed from workspaceDir
+  });
+
+  it("returns null when file not found (either path)", async () => {
+    // Assert graceful degradation
+  });
+});
+```
+
+### E2E Tests
+
+1. **Dev container with default**: `make dev` → verify SOUL.md generated
+2. **Dev container with custom path**: Set `LOA_SOUL_SOURCE` → verify custom path used
+3. **Prod container**: Deploy → verify persistence unchanged
+
+---
+
+## Security Considerations
+
+- **Path traversal**: The env var accepts any path. This is intentional for flexibility but requires trust in deployment configuration.
+- **No secrets involved**: BEAUVOIR.md contains identity config, not secrets.
+
+---
+
+## Rollback Plan
+
+If issues arise:
+
+1. Remove env var from startup scripts
+2. Revert the 2-line change in `loa-soul-generator.ts`
+3. Rebuild container
+
+**Rollback time**: < 5 minutes
+
+---
+
+## Implementation Checklist
+
+- [ ] Modify `src/agents/loa-soul-generator.ts` (2 lines)
+- [ ] Update `deploy/start-loa.sh` (3 lines)
+- [ ] Update `deploy/start-loa-dev.sh` (1 line)
+- [ ] Add unit test for env var override
+- [ ] Test dev container
+- [ ] Test prod deployment (or verify no regression)
+
+---
+
+_Generated by Loa Simstim Workflow_

--- a/src/agents/loa-soul-generator.ts
+++ b/src/agents/loa-soul-generator.ts
@@ -22,9 +22,15 @@ import * as path from "node:path";
  *
  * @param workspaceDir - The workspace directory (e.g., ~/.openclaw/workspace)
  * @returns Generated SOUL.md content, or null if BEAUVOIR.md not found/invalid
+ *
+ * Path Resolution (Loa v1.27.0 pattern):
+ * 1. LOA_SOUL_SOURCE env var (absolute path) - highest priority
+ * 2. Default: {workspaceDir}/grimoires/loa/BEAUVOIR.md
  */
 export async function tryGenerateSoulFromBeauvoir(workspaceDir: string): Promise<string | null> {
-  const beauvoirPath = path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
+  // Support configurable path via environment variable (Loa v1.27.0 pattern)
+  const beauvoirPath =
+    process.env.LOA_SOUL_SOURCE ?? path.join(workspaceDir, "grimoires/loa/BEAUVOIR.md");
 
   try {
     const content = await fs.readFile(beauvoirPath, "utf-8");


### PR DESCRIPTION
## Summary

- Add `LOA_SOUL_SOURCE` environment variable support to `loa-soul-generator.ts`
- Update startup scripts to export and log the configurable path
- Follow Loa v1.27.0 `path-lib.sh` pattern for path flexibility

## Changes

| File | Change | LOC |
|------|--------|-----|
| `src/agents/loa-soul-generator.ts` | Add env var check | +2 |
| `deploy/start-loa.sh` | Export `LOA_SOUL_SOURCE` | +6 |
| `deploy/start-loa-dev.sh` | Log `LOA_SOUL_SOURCE` | +1 |

**Total**: ~9 lines changed

## Behavior

1. If `LOA_SOUL_SOURCE` is set: Use the specified absolute path
2. If not set: Use default path `{workspace}/grimoires/loa/BEAUVOIR.md` (backward compatible)
3. If file not found: Return null, fallback to default SOUL.md template

## Test plan

- [ ] Dev container startup with default path
- [ ] Dev container startup with custom `LOA_SOUL_SOURCE`
- [ ] Verify SOUL.md generation from BEAUVOIR.md
- [ ] Verify backward compatibility (no env var set)

## References

- PRD: `grimoires/loa/soul-init-prd.md`
- SDD: `grimoires/loa/soul-init-sdd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)